### PR TITLE
Fix malloc in filesystem_engine

### DIFF
--- a/engine/common/filesystem_engine.c
+++ b/engine/common/filesystem_engine.c
@@ -73,15 +73,15 @@ qboolean FS_LoadProgs( void )
 	if (lastslash)
 	{
 		int   pathLen = lastslash - newname;
-		char *path = (char *) malloc(pathLen);
+		char *path = (char *) malloc(pathLen + sizeof(FILESYSTEM_STDIO_DLL) + sizeof("MacOS/"));
 		memcpy(path, newname, pathLen);
-		path[pathLen] = '\0';
 
-		// printf("*** FS_LoadProgs filename 2: %s\n", filename);
-		strcat( path, "MacOS/" );	
-		strcat( path, name );
-
+		strcat(path, "MacOS/");
+		strcat(path, name);
+		
 		fs_hInstance = COM_LoadLibrary( path, false, true );
+		
+		free(path);
 	}
 	else
 	{


### PR DESCRIPTION
Hi, this fixes the startup aborts that randomly happened and also the shutdown aborts that happened 100% of the time.